### PR TITLE
Fix: Remove frappe dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    "frappe~=15.0.0" # Installed and managed by bench.
 ]
 
 [build-system]


### PR DESCRIPTION
Removes the explicit 'frappe~=15.0.0' dependency from the [project.dependencies] section of pyproject.toml.

This change is to prevent errors when running `bench get-app` without the `--resolve-deps` flag. In such cases, `pip install -e .` is invoked, which attempts to find `frappe` on PyPI and fails, as `frappe` is expected to be provided and managed by the `frappe-bench` environment itself.

The comment "# Installed and managed by bench." next to the dependency indicated that it should not be fetched by pip in the standard way. This change allows the app to be installed in a bench environment without pip trying to resolve this specific dependency from PyPI.